### PR TITLE
Highlight sections on course hover

### DIFF
--- a/app/src/components/CourseDisplay.tsx
+++ b/app/src/components/CourseDisplay.tsx
@@ -1,4 +1,4 @@
-import { Course, Section } from "@scripts/soc";
+import { Course, Section, SOC_Generic } from "@scripts/soc";
 import SectionDisplay from "@components/SectionDisplay";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -6,13 +6,13 @@ import { Draggable } from "react-drag-and-drop";
 
 interface Props {
     course: Course;
-    handleHoverCourse: (courseCode: string) => void;
+    handleHoverCourse: (courseID: string) => void;
     handleUnhoverCourse: () => void;
 }
 
 export default function CourseDisplay(props: Props) {
     const sectionDisplays = props.course.sections.map((section: Section) => (
-        <SectionDisplay key={section.uid} section={section} draggable={true} hoveredCourse={null} handleRemove={function (): void {
+        <SectionDisplay key={section.uid} section={section} draggable={true} hoveredCourseID={null} handleRemove={function (): void {
             throw new Error("Course should not be able to be removed from course display.");
         } }/> // pass in null hover status because this should never be highlighted when something else is hovered
     ));
@@ -22,7 +22,7 @@ export default function CourseDisplay(props: Props) {
             {/* COURSE INFORMATION */}
             <Draggable type={"uid"} data={props.course.uid}>
                 <div className="m-1">
-                    <div className="w-full p-2 rounded-lg shadow-sm shadow-slate-400" onMouseEnter={() => props.handleHoverCourse(props.course.code)} onMouseLeave={() => props.handleUnhoverCourse()}>
+                    <div className="w-full p-2 rounded-lg shadow-sm shadow-slate-400" onMouseEnter={() => props.handleHoverCourse(SOC_Generic.getCourseID(props.course.uid))} onMouseLeave={() => props.handleUnhoverCourse()}>
                         {/* Course Code & Name */}
                         <p className="text-slate-700 underline">
                             <b>{props.course.code}</b> {props.course.name}

--- a/app/src/components/CourseDisplay.tsx
+++ b/app/src/components/CourseDisplay.tsx
@@ -6,10 +6,10 @@ import { Draggable } from "react-drag-and-drop";
 
 interface Props {
     course: Course;
-    handleHoverSection: (courseID: string | null) => void;
-    handleUnhoverSection: () => void;
-    handleHoverCourse: (courseID: string) => void;
-    handleUnhoverCourse: () => void;
+    storeHoveredElementSection: (courseID: string | null) => void;
+    forgetHoveredElementSection: () => void;
+    storeHoveredElementCourse: (courseID: string) => void;
+    forgetHoveredElementCourse: () => void;
 }
 
 export default function CourseDisplay(props: Props) {
@@ -19,11 +19,14 @@ export default function CourseDisplay(props: Props) {
         section={section}
         draggable={true}
         // pass in null hover status because this should never be highlighted when something else is hovered
-        hoveredSectionUid={null}
-        hoveredCourseId={null}
+        hoveredElementSectionUid={null}
+        hoveredElementCourseId={null}
         handleRemove={function (): void {throw new Error("Course should not be able to be removed from course display.");}}
-        handleHoverSection={props.handleHoverSection}
-        handleUnhoverSection={props.handleUnhoverSection}
+        storeHoveredElementSection={props.storeHoveredElementSection}
+        forgetHoveredElementSection={props.forgetHoveredElementSection}
+        // Pass in empty functions because hovering a section on the left shouldn't affect the "course hover" status
+        storeHoveredElementCourse={(_uid: string): void => {}}
+        forgetHoveredElementCourse={(): void => {}}
         />));
 
     return (
@@ -31,7 +34,7 @@ export default function CourseDisplay(props: Props) {
             {/* COURSE INFORMATION */}
             <Draggable type={"uid"} data={props.course.uid}>
                 <div className="m-1">
-                    <div className="w-full p-2 rounded-lg shadow-sm shadow-slate-400" onMouseEnter={() => props.handleHoverCourse(SOC_Generic.getCourseID(props.course.uid))} onMouseLeave={() => props.handleUnhoverCourse()}>
+                    <div className="w-full p-2 rounded-lg shadow-sm shadow-slate-400" onMouseEnter={() => props.storeHoveredElementCourse(SOC_Generic.getCourseID(props.course.uid))} onMouseLeave={() => props.forgetHoveredElementCourse()}>
                         {/* Course Code & Name */}
                         <p className="text-slate-700 underline">
                             <b>{props.course.code}</b> {props.course.name}

--- a/app/src/components/CourseDisplay.tsx
+++ b/app/src/components/CourseDisplay.tsx
@@ -6,16 +6,25 @@ import { Draggable } from "react-drag-and-drop";
 
 interface Props {
     course: Course;
+    handleHoverSection: (courseID: string | null) => void;
+    handleUnhoverSection: () => void;
     handleHoverCourse: (courseID: string) => void;
     handleUnhoverCourse: () => void;
 }
 
 export default function CourseDisplay(props: Props) {
     const sectionDisplays = props.course.sections.map((section: Section) => (
-        <SectionDisplay key={section.uid} section={section} draggable={true} hoveredCourseID={null} handleRemove={function (): void {
-            throw new Error("Course should not be able to be removed from course display.");
-        } }/> // pass in null hover status because this should never be highlighted when something else is hovered
-    ));
+        <SectionDisplay
+        key={section.uid}
+        section={section}
+        draggable={true}
+        // pass in null hover status because this should never be highlighted when something else is hovered
+        hoveredSectionUid={null}
+        hoveredCourseId={null}
+        handleRemove={function (): void {throw new Error("Course should not be able to be removed from course display.");}}
+        handleHoverSection={props.handleHoverSection}
+        handleUnhoverSection={props.handleUnhoverSection}
+        />));
 
     return (
         <div>

--- a/app/src/components/CourseDisplay.tsx
+++ b/app/src/components/CourseDisplay.tsx
@@ -6,11 +6,15 @@ import { Draggable } from "react-drag-and-drop";
 
 interface Props {
     course: Course;
+    handleHoverCourse: (courseCode: string) => void;
+    handleUnhoverCourse: () => void;
 }
 
 export default function CourseDisplay(props: Props) {
     const sectionDisplays = props.course.sections.map((section: Section) => (
-        <SectionDisplay key={section.uid} section={section} draggable={true} />
+        <SectionDisplay key={section.uid} section={section} draggable={true} hoveredCourse={null} handleRemove={function (): void {
+            throw new Error("Course should not be able to be removed from course display.");
+        } }/> // pass in null hover status because this should never be highlighted when something else is hovered
     ));
 
     return (
@@ -18,7 +22,7 @@ export default function CourseDisplay(props: Props) {
             {/* COURSE INFORMATION */}
             <Draggable type={"uid"} data={props.course.uid}>
                 <div className="m-1">
-                    <div className="w-full p-2 rounded-lg shadow-sm shadow-slate-400">
+                    <div className="w-full p-2 rounded-lg shadow-sm shadow-slate-400" onMouseEnter={() => props.handleHoverCourse(props.course.code)} onMouseLeave={() => props.handleUnhoverCourse()}>
                         {/* Course Code & Name */}
                         <p className="text-slate-700 underline">
                             <b>{props.course.code}</b> {props.course.name}

--- a/app/src/components/MultipleCourseDisplay.tsx
+++ b/app/src/components/MultipleCourseDisplay.tsx
@@ -3,6 +3,8 @@ import CourseDisplay from "@components/CourseDisplay";
 
 interface Props {
     courses: Course[];
+    handleHoverSection: (courseID: string | null) => void;
+    handleUnhoverSection: () => void;
     handleHoverCourse: (courseId: string) => void;
     handleUnhoverCourse: () => void;
 }
@@ -12,6 +14,8 @@ export default function MultipleCourseDisplay(props: Props) {
         <CourseDisplay
             key={course.uid}
             course={course}
+            handleHoverSection={props.handleHoverSection}
+            handleUnhoverSection={props.handleUnhoverSection}
             handleHoverCourse={props.handleHoverCourse}
             handleUnhoverCourse={props.handleUnhoverCourse}
         />

--- a/app/src/components/MultipleCourseDisplay.tsx
+++ b/app/src/components/MultipleCourseDisplay.tsx
@@ -3,7 +3,7 @@ import CourseDisplay from "@components/CourseDisplay";
 
 interface Props {
     courses: Course[];
-    handleHoverCourse: (courseCode: string) => void;
+    handleHoverCourse: (courseId: string) => void;
     handleUnhoverCourse: () => void;
 }
 

--- a/app/src/components/MultipleCourseDisplay.tsx
+++ b/app/src/components/MultipleCourseDisplay.tsx
@@ -3,11 +3,18 @@ import CourseDisplay from "@components/CourseDisplay";
 
 interface Props {
     courses: Course[];
+    handleHoverCourse: (courseCode: string) => void;
+    handleUnhoverCourse: () => void;
 }
 
 export default function MultipleCourseDisplay(props: Props) {
     const courses = props.courses.map((course: Course) => (
-        <CourseDisplay key={course.uid} course={course} />
+        <CourseDisplay
+            key={course.uid}
+            course={course}
+            handleHoverCourse={props.handleHoverCourse}
+            handleUnhoverCourse={props.handleUnhoverCourse}
+        />
     ));
 
     return <div className="my-1">{courses}</div>;

--- a/app/src/components/MultipleCourseDisplay.tsx
+++ b/app/src/components/MultipleCourseDisplay.tsx
@@ -3,10 +3,10 @@ import CourseDisplay from "@components/CourseDisplay";
 
 interface Props {
     courses: Course[];
-    handleHoverSection: (courseID: string | null) => void;
-    handleUnhoverSection: () => void;
-    handleHoverCourse: (courseId: string) => void;
-    handleUnhoverCourse: () => void;
+    storeHoveredElementSection: (courseID: string | null) => void;
+    forgetHoveredElementSection: () => void;
+    storeHoveredElementCourse: (courseId: string) => void;
+    forgetHoveredElementCourse: () => void;
 }
 
 export default function MultipleCourseDisplay(props: Props) {
@@ -14,10 +14,10 @@ export default function MultipleCourseDisplay(props: Props) {
         <CourseDisplay
             key={course.uid}
             course={course}
-            handleHoverSection={props.handleHoverSection}
-            handleUnhoverSection={props.handleUnhoverSection}
-            handleHoverCourse={props.handleHoverCourse}
-            handleUnhoverCourse={props.handleUnhoverCourse}
+            storeHoveredElementSection={props.storeHoveredElementSection}
+            forgetHoveredElementSection={props.forgetHoveredElementSection}
+            storeHoveredElementCourse={props.storeHoveredElementCourse}
+            forgetHoveredElementCourse={props.forgetHoveredElementCourse}
         />
     ));
 

--- a/app/src/components/MultipleSelectionDisplay.tsx
+++ b/app/src/components/MultipleSelectionDisplay.tsx
@@ -4,6 +4,7 @@ import SelectionDisplay from "@components/SelectionDisplay";
 
 interface Props {
     selections: Selection[];
+    hoveredCourse: string | null;
     handleDrop: (ind: number, uid: string) => Promise<void>;
     newSelection: () => void;
     handleRemove: (sectionToRemove: Section) => void;
@@ -19,6 +20,7 @@ export default function MultipleSelectionDisplay(props: Props) {
             handleDrop={props.handleDrop}
             handleRemove={props.handleRemove}
             handleDeleteSelection={props.handleDeleteSelection}
+            hoveredCourse={props.hoveredCourse}
         />
     ));
 

--- a/app/src/components/MultipleSelectionDisplay.tsx
+++ b/app/src/components/MultipleSelectionDisplay.tsx
@@ -4,7 +4,7 @@ import SelectionDisplay from "@components/SelectionDisplay";
 
 interface Props {
     selections: Selection[];
-    hoveredCourse: string | null;
+    hoveredCourseId: string | null;
     handleDrop: (ind: number, uid: string) => Promise<void>;
     newSelection: () => void;
     handleRemove: (sectionToRemove: Section) => void;
@@ -20,7 +20,7 @@ export default function MultipleSelectionDisplay(props: Props) {
             handleDrop={props.handleDrop}
             handleRemove={props.handleRemove}
             handleDeleteSelection={props.handleDeleteSelection}
-            hoveredCourse={props.hoveredCourse}
+            hoveredCourseId={props.hoveredCourseId}
         />
     ));
 

--- a/app/src/components/MultipleSelectionDisplay.tsx
+++ b/app/src/components/MultipleSelectionDisplay.tsx
@@ -10,8 +10,6 @@ interface Props {
     newSelection: () => void;
     handleRemove: (sectionToRemove: Section) => void;
     handleDeleteSelection: (ind: number) => void;
-    storeHoveredElementSection: (courseID: string | null) => void;
-    forgetHoveredElementSection: () => void;
     storeHoveredElementCourse: (courseID: string) => void;
     forgetHoveredElementCourse: () => void;
 }
@@ -29,8 +27,9 @@ export default function MultipleSelectionDisplay(props: Props) {
             handleDrop={props.handleDrop}
             handleRemove={props.handleRemove}
             handleDeleteSelection={props.handleDeleteSelection}
-            storeHoveredElementSection={props.storeHoveredElementSection}
-            forgetHoveredElementSection={props.forgetHoveredElementSection}
+            // These functions do not do anything because we should not highlight a section in the middle after hovering over it
+            storeHoveredElementSection={(_uid) => null}
+            forgetHoveredElementSection={() => null}
             storeHoveredElementCourse={props.storeHoveredElementCourse}
             forgetHoveredElementCourse={props.forgetHoveredElementCourse}
         />

--- a/app/src/components/MultipleSelectionDisplay.tsx
+++ b/app/src/components/MultipleSelectionDisplay.tsx
@@ -4,14 +4,16 @@ import SelectionDisplay from "@components/SelectionDisplay";
 
 interface Props {
     selections: Selection[];
-    hoveredCourseId: string | null;
-    hoveredSectionUid: string | null;
+    hoveredElementCourseId: string | null;
+    hoveredElementSectionUid: string | null;
     handleDrop: (ind: number, uid: string) => Promise<void>;
     newSelection: () => void;
     handleRemove: (sectionToRemove: Section) => void;
     handleDeleteSelection: (ind: number) => void;
-    handleHoverSection: (courseID: string | null) => void;
-    handleUnhoverSection: () => void;
+    storeHoveredElementSection: (courseID: string | null) => void;
+    forgetHoveredElementSection: () => void;
+    storeHoveredElementCourse: (courseID: string) => void;
+    forgetHoveredElementCourse: () => void;
 }
 
 export default function MultipleSelectionDisplay(props: Props) {
@@ -20,13 +22,15 @@ export default function MultipleSelectionDisplay(props: Props) {
         <SelectionDisplay
             ind={i}
             selection={sel}
-            hoveredSectionUid={props.hoveredSectionUid}
-            hoveredCourseId={props.hoveredCourseId}
+            hoveredElementSectionUid={props.hoveredElementSectionUid}
+            hoveredElementCourseId={props.hoveredElementCourseId}
             handleDrop={props.handleDrop}
             handleRemove={props.handleRemove}
             handleDeleteSelection={props.handleDeleteSelection}
-            handleHoverSection={props.handleHoverSection}
-            handleUnhoverSection={props.handleUnhoverSection}
+            storeHoveredElementSection={props.storeHoveredElementSection}
+            forgetHoveredElementSection={props.forgetHoveredElementSection}
+            storeHoveredElementCourse={props.storeHoveredElementCourse}
+            forgetHoveredElementCourse={props.forgetHoveredElementCourse}
         />
     ));
 

--- a/app/src/components/MultipleSelectionDisplay.tsx
+++ b/app/src/components/MultipleSelectionDisplay.tsx
@@ -5,10 +5,13 @@ import SelectionDisplay from "@components/SelectionDisplay";
 interface Props {
     selections: Selection[];
     hoveredCourseId: string | null;
+    hoveredSectionUid: string | null;
     handleDrop: (ind: number, uid: string) => Promise<void>;
     newSelection: () => void;
     handleRemove: (sectionToRemove: Section) => void;
     handleDeleteSelection: (ind: number) => void;
+    handleHoverSection: (courseID: string | null) => void;
+    handleUnhoverSection: () => void;
 }
 
 export default function MultipleSelectionDisplay(props: Props) {
@@ -17,10 +20,13 @@ export default function MultipleSelectionDisplay(props: Props) {
         <SelectionDisplay
             ind={i}
             selection={sel}
+            hoveredSectionUid={props.hoveredSectionUid}
+            hoveredCourseId={props.hoveredCourseId}
             handleDrop={props.handleDrop}
             handleRemove={props.handleRemove}
             handleDeleteSelection={props.handleDeleteSelection}
-            hoveredCourseId={props.hoveredCourseId}
+            handleHoverSection={props.handleHoverSection}
+            handleUnhoverSection={props.handleUnhoverSection}
         />
     ));
 

--- a/app/src/components/ScheduleBuilder.tsx
+++ b/app/src/components/ScheduleBuilder.tsx
@@ -292,9 +292,6 @@ export default class ScheduleBuilder extends Component<Props, States> {
                                 this,
                             )}
                             key={new Date().getTime()}
-                            // These functions do not do anything because we do not highlight a section in the middle after hovering over it
-                            storeHoveredElementSection={(_uid) => null}
-                            forgetHoveredElementSection={() => null}
                             storeHoveredElementCourse={this.storeHoveredElementCourse.bind(this)}
                             forgetHoveredElementCourse={this.forgetHoveredElementCourse.bind(this)}
                         />

--- a/app/src/components/ScheduleBuilder.tsx
+++ b/app/src/components/ScheduleBuilder.tsx
@@ -29,7 +29,7 @@ interface States {
     showAddCourse: boolean;
     // string of either the course code being hovered
     // null when no course is being hovered that would require a highlight change somewhere else
-    hoveredCourse: string | null;
+    hoveredCourseId: string | null;
 }
 
 const defaultState: States = {
@@ -41,7 +41,7 @@ const defaultState: States = {
     selections: getDefaultSelections(),
     schedules: [],
     showAddCourse: false,
-    hoveredCourse: null
+    hoveredCourseId: null
 };
 
 export default class ScheduleBuilder extends Component<Props, States> {
@@ -175,11 +175,11 @@ export default class ScheduleBuilder extends Component<Props, States> {
         this.setState({ selections: newSelections });
     }
 
-    handleHoverCourse(code: string) {
-        this.setState({hoveredCourse: code});
+    handleHoverCourse(courseId: string) {
+        this.setState({hoveredCourseId: courseId});
     }
     handleUnhoverCourse() {
-        this.setState({hoveredCourse: null})
+        this.setState({hoveredCourseId: null})
     }
 
     render() {
@@ -264,7 +264,7 @@ export default class ScheduleBuilder extends Component<Props, States> {
                     {/* Selected */}
                     <div className="overflow-y-auto w-full p-1">
                         <MultipleSelectionDisplay
-                            hoveredCourse={this.state.hoveredCourse}
+                            hoveredCourseId={this.state.hoveredCourseId}
                             selections={this.state.selections}
                             handleDrop={this.handleDrop.bind(this)}
                             newSelection={this.newSelection.bind(this)}

--- a/app/src/components/ScheduleBuilder.tsx
+++ b/app/src/components/ScheduleBuilder.tsx
@@ -27,6 +27,9 @@ interface States {
     selections: Selection[];
     schedules: Schedule[];
     showAddCourse: boolean;
+    // string of either the course code being hovered
+    // null when no course is being hovered that would require a highlight change somewhere else
+    hoveredCourse: string | null;
 }
 
 const defaultState: States = {
@@ -38,6 +41,7 @@ const defaultState: States = {
     selections: getDefaultSelections(),
     schedules: [],
     showAddCourse: false,
+    hoveredCourse: null
 };
 
 export default class ScheduleBuilder extends Component<Props, States> {
@@ -171,6 +175,13 @@ export default class ScheduleBuilder extends Component<Props, States> {
         this.setState({ selections: newSelections });
     }
 
+    handleHoverCourse(code: string) {
+        this.setState({hoveredCourse: code});
+    }
+    handleUnhoverCourse() {
+        this.setState({hoveredCourse: null})
+    }
+
     render() {
         // Show loading screen if filters/terms haven't been fetched yet
         if (this.state.filters === null)
@@ -245,12 +256,15 @@ export default class ScheduleBuilder extends Component<Props, States> {
                             setSearchText={(searchText) => {
                                 this.setState.bind(this)({ searchText });
                             }}
+                            handleHoverCourse={this.handleHoverCourse.bind(this)}
+                            handleUnhoverCourse={this.handleUnhoverCourse.bind(this)}
                         />
                     </div>
 
                     {/* Selected */}
                     <div className="overflow-y-auto w-full p-1">
                         <MultipleSelectionDisplay
+                            hoveredCourse={this.state.hoveredCourse}
                             selections={this.state.selections}
                             handleDrop={this.handleDrop.bind(this)}
                             newSelection={this.newSelection.bind(this)}

--- a/app/src/components/ScheduleBuilder.tsx
+++ b/app/src/components/ScheduleBuilder.tsx
@@ -28,11 +28,11 @@ interface States {
     schedules: Schedule[];
     showAddCourse: boolean;
     // string of the courseUID#sectionUID being hovered, corresponding to a given SectionDisplay element
-    // null when no section is being hovered
-    hoveredSectionUid: string | null;
-    // string of the course ID being hovered, corresponding to a given CourseDisplay element
-    // null when no course is being hovered that would require a highlight change somewhere else
-    hoveredCourseId: string | null;
+    // null when no section on the left is being hovered
+    hoveredElementSectionUid: string | null;
+    // string of the course ID of the element being hovered.
+    // null when no element is being hovered that would require a highlight change for all elements with the same course
+    hoveredElementCourseId: string | null;
 }
 
 const defaultState: States = {
@@ -44,8 +44,8 @@ const defaultState: States = {
     selections: getDefaultSelections(),
     schedules: [],
     showAddCourse: false,
-    hoveredSectionUid: null,
-    hoveredCourseId: null
+    hoveredElementSectionUid: null,
+    hoveredElementCourseId: null
 };
 
 export default class ScheduleBuilder extends Component<Props, States> {
@@ -179,18 +179,28 @@ export default class ScheduleBuilder extends Component<Props, States> {
         this.setState({ selections: newSelections });
     }
 
-    handleHoverSection(sectionId: string | null) {
-        this.setState({hoveredSectionUid: sectionId});
-    }
-    handleUnhoverSection() {
-        this.setState({hoveredSectionUid: null})
+    // Stores both the course and section for an element, which is used to highlight
+    // only elements that are the same exact section
+    storeHoveredElementSection(sectionId: string | null) {
+        if (this.state.hoveredElementSectionUid != sectionId) {
+            this.setState({ hoveredElementSectionUid: sectionId });
+        }
     }
 
-    handleHoverCourse(courseId: string) {
-        this.setState({hoveredCourseId: courseId});
+    forgetHoveredElementSection() {
+        this.setState({ hoveredElementSectionUid: null })
     }
-    handleUnhoverCourse() {
-        this.setState({hoveredCourseId: null})
+
+    // Stores just the course information of an element, which is used to highlight
+    // all other elements of the same course
+    storeHoveredElementCourse(courseId: string) {
+        if (this.state.hoveredElementCourseId != courseId) {
+            this.setState({ hoveredElementCourseId: courseId });
+        }
+    }
+
+    forgetHoveredElementCourse() {
+        this.setState({ hoveredElementCourseId: null })
     }
 
     render() {
@@ -267,10 +277,10 @@ export default class ScheduleBuilder extends Component<Props, States> {
                             setSearchText={(searchText) => {
                                 this.setState.bind(this)({ searchText });
                             }}
-                            handleHoverSection={this.handleHoverSection.bind(this)}
-                            handleUnhoverSection={this.handleUnhoverSection.bind(this)}
-                            handleHoverCourse={this.handleHoverCourse.bind(this)}
-                            handleUnhoverCourse={this.handleUnhoverCourse.bind(this)}
+                            storeHoveredElementSection={this.storeHoveredElementSection.bind(this)}
+                            forgetHoveredElementSection={this.forgetHoveredElementSection.bind(this)}
+                            storeHoveredElementCourse={this.storeHoveredElementCourse.bind(this)}
+                            forgetHoveredElementCourse={this.forgetHoveredElementCourse.bind(this)}
                         />
                     </div>
 
@@ -278,8 +288,8 @@ export default class ScheduleBuilder extends Component<Props, States> {
                     <div className="overflow-y-auto w-full p-1">
                         <MultipleSelectionDisplay
                             selections={this.state.selections}
-                            hoveredCourseId={this.state.hoveredCourseId}
-                            hoveredSectionUid={this.state.hoveredSectionUid}
+                            hoveredElementCourseId={this.state.hoveredElementCourseId}
+                            hoveredElementSectionUid={this.state.hoveredElementSectionUid}
                             handleDrop={this.handleDrop.bind(this)}
                             newSelection={this.newSelection.bind(this)}
                             handleRemove={this.handleRemove.bind(this)}
@@ -288,8 +298,10 @@ export default class ScheduleBuilder extends Component<Props, States> {
                             )}
                             key={new Date().getTime()}
                             // These functions do not do anything because we do not highlight a section in the middle after hovering over it
-                            handleHoverSection={(_uid) => null}
-                            handleUnhoverSection={() => null}
+                            storeHoveredElementSection={(_uid) => null}
+                            forgetHoveredElementSection={() => null}
+                            storeHoveredElementCourse={this.storeHoveredElementCourse.bind(this)}
+                            forgetHoveredElementCourse={this.forgetHoveredElementCourse.bind(this)}
                         />
                     </div>
 

--- a/app/src/components/ScheduleBuilder.tsx
+++ b/app/src/components/ScheduleBuilder.tsx
@@ -27,7 +27,10 @@ interface States {
     selections: Selection[];
     schedules: Schedule[];
     showAddCourse: boolean;
-    // string of either the course code being hovered
+    // string of the courseUID#sectionUID being hovered, corresponding to a given SectionDisplay element
+    // null when no section is being hovered
+    hoveredSectionUid: string | null;
+    // string of the course ID being hovered, corresponding to a given CourseDisplay element
     // null when no course is being hovered that would require a highlight change somewhere else
     hoveredCourseId: string | null;
 }
@@ -41,6 +44,7 @@ const defaultState: States = {
     selections: getDefaultSelections(),
     schedules: [],
     showAddCourse: false,
+    hoveredSectionUid: null,
     hoveredCourseId: null
 };
 
@@ -175,6 +179,13 @@ export default class ScheduleBuilder extends Component<Props, States> {
         this.setState({ selections: newSelections });
     }
 
+    handleHoverSection(sectionId: string | null) {
+        this.setState({hoveredSectionUid: sectionId});
+    }
+    handleUnhoverSection() {
+        this.setState({hoveredSectionUid: null})
+    }
+
     handleHoverCourse(courseId: string) {
         this.setState({hoveredCourseId: courseId});
     }
@@ -256,6 +267,8 @@ export default class ScheduleBuilder extends Component<Props, States> {
                             setSearchText={(searchText) => {
                                 this.setState.bind(this)({ searchText });
                             }}
+                            handleHoverSection={this.handleHoverSection.bind(this)}
+                            handleUnhoverSection={this.handleUnhoverSection.bind(this)}
                             handleHoverCourse={this.handleHoverCourse.bind(this)}
                             handleUnhoverCourse={this.handleUnhoverCourse.bind(this)}
                         />
@@ -264,8 +277,9 @@ export default class ScheduleBuilder extends Component<Props, States> {
                     {/* Selected */}
                     <div className="overflow-y-auto w-full p-1">
                         <MultipleSelectionDisplay
-                            hoveredCourseId={this.state.hoveredCourseId}
                             selections={this.state.selections}
+                            hoveredCourseId={this.state.hoveredCourseId}
+                            hoveredSectionUid={this.state.hoveredSectionUid}
                             handleDrop={this.handleDrop.bind(this)}
                             newSelection={this.newSelection.bind(this)}
                             handleRemove={this.handleRemove.bind(this)}
@@ -273,6 +287,9 @@ export default class ScheduleBuilder extends Component<Props, States> {
                                 this,
                             )}
                             key={new Date().getTime()}
+                            // These functions do not do anything because we do not highlight a section in the middle after hovering over it
+                            handleHoverSection={(_uid) => null}
+                            handleUnhoverSection={() => null}
                         />
                     </div>
 

--- a/app/src/components/SectionDisplay.tsx
+++ b/app/src/components/SectionDisplay.tsx
@@ -11,12 +11,19 @@ import { notNullish } from "@scripts/utils.ts";
 interface Props {
     section: Section;
     draggable: boolean;
-    hoveredCourseID: string | null;
+    hoveredSectionUid: string | null;
+    hoveredCourseId: string | null;
     handleRemove: (sectionToRemove: Section) => void;
+    handleHoverSection: (courseID: string | null) => void;
+    handleUnhoverSection: () => void;
 }
 
 export default function SectionDisplay(props: Props) {
     const section = props.section;
+
+    function needsHighlight(): boolean {
+        return (props.hoveredSectionUid == props.section.uid) || (props.hoveredCourseId == SOC_Generic.getCourseID(props.section.uid));
+    }
 
     // TODO: refactor
     let allTimes: React.JSX.Element[] = API_Days.map((day) =>
@@ -52,7 +59,11 @@ export default function SectionDisplay(props: Props) {
                 {" "}
                 {/* SECTION */}
                 {/*Note that there is a white border when the section is not highlighted because otherwise the graphics will shift between having a border and not having a border, which shifts the size of the section blocks*/}
-                <div className={props.hoveredCourseID == SOC_Generic.getCourseID(props.section.uid) ? "w-full p-2 rounded-lg shadow-sm shadow-slate-400 bg-slate-200 border border-blue-300" : "w-full p-2 rounded-lg shadow-sm shadow-slate-400 border border-white"}>
+                <div
+                    className={needsHighlight() ? "w-full p-2 rounded-lg shadow-sm shadow-slate-400 bg-slate-200 border border-blue-300" : "w-full p-2 rounded-lg shadow-sm shadow-slate-400 border border-white"}
+                    onMouseEnter={() => props.handleHoverSection(props.section.uid)}
+                    onMouseLeave={() => props.handleUnhoverSection()}
+                >
                     <div className={"text-slate-600 flex justify-between"}>
                         <div className={"flex items-center gap-1"}>
                             <b>{section.number}</b>
@@ -90,3 +101,4 @@ export default function SectionDisplay(props: Props) {
         </Draggable>
     );
 }
+

--- a/app/src/components/SectionDisplay.tsx
+++ b/app/src/components/SectionDisplay.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Section } from "@scripts/soc";
+import { Section, SOC_Generic } from "@scripts/soc";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { Draggable } from "react-drag-and-drop";
@@ -11,16 +11,9 @@ import { notNullish } from "@scripts/utils.ts";
 interface Props {
     section: Section;
     draggable: boolean;
-    hoveredCourse: string | null;
+    hoveredCourseID: string | null;
     handleRemove: (sectionToRemove: Section) => void;
 }
-
-interface States {}
-
-const defaultProps = {
-    draggable: false,
-    handleRemove: null,
-};
 
 export default function SectionDisplay(props: Props) {
     const section = props.section;
@@ -58,7 +51,8 @@ export default function SectionDisplay(props: Props) {
             <div className="m-1 text-sm">
                 {" "}
                 {/* SECTION */}
-                <div className={props.hoveredCourse == section.courseCode ? "w-full p-2 rounded-lg shadow-sm shadow-slate-400 bg-slate-200" : "w-full p-2 rounded-lg shadow-sm shadow-slate-400"}>
+                {/*Note that there is a white border when the section is not highlighted because otherwise the graphics will shift between having a border and not having a border, which shifts the size of the section blocks*/}
+                <div className={props.hoveredCourseID == SOC_Generic.getCourseID(props.section.uid) ? "w-full p-2 rounded-lg shadow-sm shadow-slate-400 bg-slate-200 border border-blue-300" : "w-full p-2 rounded-lg shadow-sm shadow-slate-400 border border-white"}>
                     <div className={"text-slate-600 flex justify-between"}>
                         <div className={"flex items-center gap-1"}>
                             <b>{section.number}</b>
@@ -95,5 +89,4 @@ export default function SectionDisplay(props: Props) {
             </div>
         </Draggable>
     );
-
 }

--- a/app/src/components/SectionDisplay.tsx
+++ b/app/src/components/SectionDisplay.tsx
@@ -11,18 +11,30 @@ import { notNullish } from "@scripts/utils.ts";
 interface Props {
     section: Section;
     draggable: boolean;
-    hoveredSectionUid: string | null;
-    hoveredCourseId: string | null;
+    hoveredElementSectionUid: string | null;
+    hoveredElementCourseId: string | null;
     handleRemove: (sectionToRemove: Section) => void;
-    handleHoverSection: (courseID: string | null) => void;
-    handleUnhoverSection: () => void;
+    storeHoveredElementSection: (courseID: string | null) => void;
+    forgetHoveredElementSection: () => void;
+    storeHoveredElementCourse: (courseID: string) => void;
+    forgetHoveredElementCourse: () => void;
 }
 
 export default function SectionDisplay(props: Props) {
     const section = props.section;
 
-    function needsHighlight(): boolean {
-        return (props.hoveredSectionUid == props.section.uid) || (props.hoveredCourseId == SOC_Generic.getCourseID(props.section.uid));
+    const storeHoveredElementSection = (): void => {
+        props.storeHoveredElementSection(props.section.uid)
+        props.storeHoveredElementCourse(SOC_Generic.getCourseID(props.section.uid));
+    }
+
+    const forgetHoveredElementSection = (): void => {
+        props.forgetHoveredElementSection();
+        props.forgetHoveredElementCourse();
+    }
+
+    const needsHighlight= (): boolean => {
+        return (props.hoveredElementSectionUid == props.section.uid) || (props.hoveredElementCourseId == SOC_Generic.getCourseID(props.section.uid));
     }
 
     // TODO: refactor
@@ -61,8 +73,8 @@ export default function SectionDisplay(props: Props) {
                 {/*Note that there is a white border when the section is not highlighted because otherwise the graphics will shift between having a border and not having a border, which shifts the size of the section blocks*/}
                 <div
                     className={needsHighlight() ? "w-full p-2 rounded-lg shadow-sm shadow-slate-400 bg-slate-200 border border-blue-300" : "w-full p-2 rounded-lg shadow-sm shadow-slate-400 border border-white"}
-                    onMouseEnter={() => props.handleHoverSection(props.section.uid)}
-                    onMouseLeave={() => props.handleUnhoverSection()}
+                    onMouseEnter={() => storeHoveredElementSection()}
+                    onMouseLeave={() => forgetHoveredElementSection()}
                 >
                     <div className={"text-slate-600 flex justify-between"}>
                         <div className={"flex items-center gap-1"}>

--- a/app/src/components/SectionDisplay.tsx
+++ b/app/src/components/SectionDisplay.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 import { Section } from "@scripts/soc";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -11,6 +11,7 @@ import { notNullish } from "@scripts/utils.ts";
 interface Props {
     section: Section;
     draggable: boolean;
+    hoveredCourse: string | null;
     handleRemove: (sectionToRemove: Section) => void;
 }
 
@@ -21,81 +22,78 @@ const defaultProps = {
     handleRemove: null,
 };
 
-export default class SectionDisplay extends Component<Props, States> {
-    static defaultProps = defaultProps;
+export default function SectionDisplay(props: Props) {
+    const section = props.section;
 
-    render() {
-        const section = this.props.section;
+    // TODO: refactor
+    let allTimes: React.JSX.Element[] = API_Days.map((day) =>
+        section.meetings[day].length > 0 ? (
+            <div className="mx-1">
+                <b>{day}:</b>{" "}
+                {section.meetings[day].map((mT) => (
+                    <span>
+                        {CampusMap.createLink(
+                            mT.locationID,
+                            `${mT.bldg} ${mT.room}`,
+                            <>{mT.formatPeriods()}</>,
+                        )}{" "}
+                    </span>
+                ))}
+            </div>
+        ) : null,
+    ).filter(notNullish);
 
-        // TODO: refactor
-        let allTimes: React.JSX.Element[] = API_Days.map((day) =>
-            section.meetings[day].length > 0 ? (
-                <div className="mx-1">
-                    <b>{day}:</b>{" "}
-                    {section.meetings[day].map((mT) => (
-                        <span>
-                            {CampusMap.createLink(
-                                mT.locationID,
-                                `${mT.location}`,
-                                <>{mT.formatPeriods()}</>,
-                            )}{" "}
-                        </span>
-                    ))}
-                </div>
-            ) : null,
-        ).filter(notNullish);
+    if (section.isOnline) allTimes.unshift(<b>Online</b>);
+    else if (allTimes.length == 0)
+        // Not online, but no times have been assigned
+        allTimes = [<>TBD</>];
 
-        if (section.isOnline) allTimes.unshift(<b>Online</b>);
-        else if (allTimes.length == 0)
-            // Not online, but no times have been assigned
-            allTimes = [<>TBD</>];
-
-        return (
-            <Draggable
-                className={"inline-block"}
-                type={"uid"}
-                data={section.uid}
-                enabled={this.props.draggable}
-            >
-                <div className="m-1 text-sm">
-                    {" "}
-                    {/* SECTION */}
-                    <div className="w-full p-2 rounded-lg shadow-sm shadow-slate-400">
-                        <div className={"text-slate-600 flex justify-between"}>
-                            <div className={"flex items-center gap-1"}>
-                                <b>{section.number}</b>
-                                <span className={"text-xs align-middle"}>
-                                    ({section.credits.display} Credits)
-                                </span>
-                            </div>
-                            <button
-                                className={"mx-1"}
-                                hidden={!this.props.handleRemove}
-                                onClick={() => this.props.handleRemove(section)}
-                            >
-                                <GrClose />
-                            </button>
+    return (
+        <Draggable
+            className={"inline-block"}
+            type={"uid"}
+            data={section.uid}
+            enabled={props.draggable}
+        >
+            <div className="m-1 text-sm">
+                {" "}
+                {/* SECTION */}
+                <div className={props.hoveredCourse == section.courseCode ? "w-full p-2 rounded-lg shadow-sm shadow-slate-400 bg-slate-200" : "w-full p-2 rounded-lg shadow-sm shadow-slate-400"}>
+                    <div className={"text-slate-600 flex justify-between"}>
+                        <div className={"flex items-center gap-1"}>
+                            <b>{section.number}</b>
+                            <span className={"text-xs align-middle"}>
+                                ({section.credits.display} Credits)
+                            </span>
                         </div>
+                        <button
+                            className={"mx-1"}
+                            hidden={!props.handleRemove}
+                            onClick={() => props.handleRemove(section)}
+                        >
+                            <GrClose />
+                        </button>
+                    </div>
 
-                        <div className={"text-slate-400"}>
-                            <p className={"flex items-center gap-1"}>
-                                {section.deptControlled && (
-                                    <abbr title={"Departmentally Controlled"}>
-                                        <GrLock />
-                                    </abbr>
-                                )}
-                                {section.displayName}
-                            </p>
-                            <p>
-                                <i>{section.instructors.join(", ")}</i>
-                            </p>
-                            <div className={"flex flex-row justify-around"}>
-                                {allTimes}
-                            </div>
+                    <div className={"text-slate-400"}>
+                        <p className={"flex items-center gap-1"}>
+                            {section.deptControlled && (
+                                <abbr title={"Departmentally Controlled"}>
+                                    <GrLock />
+                                </abbr>
+                            )}
+                            {section.displayName}
+                        </p>
+                        <p>
+                            <i>{section.instructors.join(", ")}</i>
+                        </p>
+                        <div className={"flex flex-row justify-around"}>
+                            {allTimes}
                         </div>
                     </div>
                 </div>
-            </Draggable>
-        );
-    }
+            </div>
+        </Draggable>
+    );
+
 }

--- a/app/src/components/SectionPicker.tsx
+++ b/app/src/components/SectionPicker.tsx
@@ -9,6 +9,8 @@ interface Props {
     soc: SOC_Generic;
     searchText: string;
     setSearchText: (searchText: string) => void;
+    handleHoverSection: (courseID: string | null) => void;
+    handleUnhoverSection: () => void;
     handleHoverCourse: (courseId: string) => void;
     handleUnhoverCourse: () => void;
 }
@@ -88,6 +90,8 @@ export default function SectionPicker(props: Props) {
 
             <MultipleCourseDisplay
                 courses={displayCourses}
+                handleHoverSection={props.handleHoverSection}
+                handleUnhoverSection={props.handleUnhoverSection}
                 handleHoverCourse={props.handleHoverCourse}
                 handleUnhoverCourse={props.handleUnhoverCourse}
             />

--- a/app/src/components/SectionPicker.tsx
+++ b/app/src/components/SectionPicker.tsx
@@ -9,6 +9,8 @@ interface Props {
     soc: SOC_Generic;
     searchText: string;
     setSearchText: (searchText: string) => void;
+    handleHoverCourse: (courseCode: string) => void;
+    handleUnhoverCourse: () => void;
 }
 
 export default function SectionPicker(props: Props) {
@@ -84,7 +86,11 @@ export default function SectionPicker(props: Props) {
                 />
             </div>
 
-            <MultipleCourseDisplay courses={displayCourses} />
+            <MultipleCourseDisplay
+                courses={displayCourses}
+                handleHoverCourse={props.handleHoverCourse}
+                handleUnhoverCourse={props.handleUnhoverCourse}
+            />
         </div>
     );
 }

--- a/app/src/components/SectionPicker.tsx
+++ b/app/src/components/SectionPicker.tsx
@@ -9,10 +9,10 @@ interface Props {
     soc: SOC_Generic;
     searchText: string;
     setSearchText: (searchText: string) => void;
-    handleHoverSection: (courseID: string | null) => void;
-    handleUnhoverSection: () => void;
-    handleHoverCourse: (courseId: string) => void;
-    handleUnhoverCourse: () => void;
+    storeHoveredElementSection: (courseID: string | null) => void;
+    forgetHoveredElementSection: () => void;
+    storeHoveredElementCourse: (courseId: string) => void;
+    forgetHoveredElementCourse: () => void;
 }
 
 export default function SectionPicker(props: Props) {
@@ -90,10 +90,10 @@ export default function SectionPicker(props: Props) {
 
             <MultipleCourseDisplay
                 courses={displayCourses}
-                handleHoverSection={props.handleHoverSection}
-                handleUnhoverSection={props.handleUnhoverSection}
-                handleHoverCourse={props.handleHoverCourse}
-                handleUnhoverCourse={props.handleUnhoverCourse}
+                storeHoveredElementSection={props.storeHoveredElementSection}
+                forgetHoveredElementSection={props.forgetHoveredElementSection}
+                storeHoveredElementCourse={props.storeHoveredElementCourse}
+                forgetHoveredElementCourse={props.forgetHoveredElementCourse}
             />
         </div>
     );

--- a/app/src/components/SectionPicker.tsx
+++ b/app/src/components/SectionPicker.tsx
@@ -9,7 +9,7 @@ interface Props {
     soc: SOC_Generic;
     searchText: string;
     setSearchText: (searchText: string) => void;
-    handleHoverCourse: (courseCode: string) => void;
+    handleHoverCourse: (courseId: string) => void;
     handleUnhoverCourse: () => void;
 }
 

--- a/app/src/components/SelectionDisplay.tsx
+++ b/app/src/components/SelectionDisplay.tsx
@@ -9,13 +9,15 @@ import { GrClose } from "react-icons/gr";
 interface Props {
     ind: number;
     selection: Selection;
-    hoveredSectionUid: string | null;
-    hoveredCourseId: string | null;
+    hoveredElementSectionUid: string | null;
+    hoveredElementCourseId: string | null;
     handleDrop: (ind: number, uid: string) => Promise<void>;
     handleRemove: (sectionToRemove: Section) => void;
     handleDeleteSelection: (ind: number) => void;
-    handleHoverSection: (courseID: string | null) => void;
-    handleUnhoverSection: () => void;
+    storeHoveredElementSection: (courseID: string | null) => void;
+    forgetHoveredElementSection: () => void;
+    storeHoveredElementCourse: (courseID: string) => void;
+    forgetHoveredElementCourse: () => void;
 }
 
 export default function SelectionDisplay(props: Props) {
@@ -27,11 +29,13 @@ export default function SelectionDisplay(props: Props) {
         <SectionDisplay 
             section={section} 
             draggable={false}
-            hoveredSectionUid={props.hoveredSectionUid} 
-            hoveredCourseId={props.hoveredCourseId} 
+            hoveredElementSectionUid={props.hoveredElementSectionUid}
+            hoveredElementCourseId={props.hoveredElementCourseId}
             handleRemove={props.handleRemove}
-            handleHoverSection={props.handleHoverSection}
-            handleUnhoverSection={props.handleUnhoverSection}
+            storeHoveredElementSection={props.storeHoveredElementSection}
+            forgetHoveredElementSection={props.forgetHoveredElementSection}
+            storeHoveredElementCourse={props.storeHoveredElementCourse}
+            forgetHoveredElementCourse={props.forgetHoveredElementCourse}
         />
     ));
 

--- a/app/src/components/SelectionDisplay.tsx
+++ b/app/src/components/SelectionDisplay.tsx
@@ -9,10 +9,13 @@ import { GrClose } from "react-icons/gr";
 interface Props {
     ind: number;
     selection: Selection;
+    hoveredSectionUid: string | null;
     hoveredCourseId: string | null;
     handleDrop: (ind: number, uid: string) => Promise<void>;
     handleRemove: (sectionToRemove: Section) => void;
     handleDeleteSelection: (ind: number) => void;
+    handleHoverSection: (courseID: string | null) => void;
+    handleUnhoverSection: () => void;
 }
 
 export default function SelectionDisplay(props: Props) {
@@ -21,8 +24,15 @@ export default function SelectionDisplay(props: Props) {
     };
 
     const sectionDisplays = props.selection.map((section: Section) => (
-        <SectionDisplay section={section} handleRemove={props.handleRemove}
-        hoveredCourseID={props.hoveredCourseId} draggable={false}/>
+        <SectionDisplay 
+            section={section} 
+            draggable={false}
+            hoveredSectionUid={props.hoveredSectionUid} 
+            hoveredCourseId={props.hoveredCourseId} 
+            handleRemove={props.handleRemove}
+            handleHoverSection={props.handleHoverSection}
+            handleUnhoverSection={props.handleUnhoverSection}
+        />
     ));
 
     return (

--- a/app/src/components/SelectionDisplay.tsx
+++ b/app/src/components/SelectionDisplay.tsx
@@ -9,7 +9,7 @@ import { GrClose } from "react-icons/gr";
 interface Props {
     ind: number;
     selection: Selection;
-    hoveredCourse: string | null;
+    hoveredCourseId: string | null;
     handleDrop: (ind: number, uid: string) => Promise<void>;
     handleRemove: (sectionToRemove: Section) => void;
     handleDeleteSelection: (ind: number) => void;
@@ -22,7 +22,7 @@ export default function SelectionDisplay(props: Props) {
 
     const sectionDisplays = props.selection.map((section: Section) => (
         <SectionDisplay section={section} handleRemove={props.handleRemove}
-        hoveredCourse={props.hoveredCourse} draggable={false}/>
+        hoveredCourseID={props.hoveredCourseId} draggable={false}/>
     ));
 
     return (

--- a/app/src/components/SelectionDisplay.tsx
+++ b/app/src/components/SelectionDisplay.tsx
@@ -9,6 +9,7 @@ import { GrClose } from "react-icons/gr";
 interface Props {
     ind: number;
     selection: Selection;
+    hoveredCourse: string | null;
     handleDrop: (ind: number, uid: string) => Promise<void>;
     handleRemove: (sectionToRemove: Section) => void;
     handleDeleteSelection: (ind: number) => void;
@@ -20,7 +21,8 @@ export default function SelectionDisplay(props: Props) {
     };
 
     const sectionDisplays = props.selection.map((section: Section) => (
-        <SectionDisplay section={section} handleRemove={props.handleRemove} />
+        <SectionDisplay section={section} handleRemove={props.handleRemove}
+        hoveredCourse={props.hoveredCourse} draggable={false}/>
     ));
 
     return (

--- a/app/src/scripts/soc/soc.tsx
+++ b/app/src/scripts/soc/soc.tsx
@@ -76,6 +76,24 @@ export abstract class SOC_Generic {
     }
 
     /**
+     * Used to get the course ID from a course/section's UID.
+     * @param uid -- The course's UID.
+     * @returns The course ID.
+     */
+    static getCourseID(uid: string): string {
+        return SOC_Generic.splitUID(uid).courseUID;
+    }
+
+        /**
+     * Used to get a section's ID from its UID.
+     * @param uid -- The section's UID.
+     * @returns The section ID, or null if the passed UID does not correspond to a section
+     */
+        static getSectionID(uid: string): string | null {
+            return SOC_Generic.splitUID(uid).sectionUID;
+        }
+
+    /**
      * Used to get a course/section from the SOC.
      * @param uid -- The course/section's UID.
      * @returns The course/section; null if there are no matches.

--- a/app/src/scripts/soc/soc.tsx
+++ b/app/src/scripts/soc/soc.tsx
@@ -84,15 +84,6 @@ export abstract class SOC_Generic {
         return SOC_Generic.splitUID(uid).courseUID;
     }
 
-        /**
-     * Used to get a section's ID from its UID.
-     * @param uid -- The section's UID.
-     * @returns The section ID, or null if the passed UID does not correspond to a section
-     */
-        static getSectionID(uid: string): string | null {
-            return SOC_Generic.splitUID(uid).sectionUID;
-        }
-
     /**
      * Used to get a course/section from the SOC.
      * @param uid -- The course/section's UID.


### PR DESCRIPTION
Addresses part of https://github.com/ufosc/SwampScheduler/issues/29.

Make it so when courses are hovered on the left, sections in the middle are highlighted. I can add functionality to highlight sections on section hover in this branch later using a similar pattern.