### PR TITLE
Save selected courses/sections across browser sessions

### DIFF
--- a/app/src/components/ScheduleBuilder.tsx
+++ b/app/src/components/ScheduleBuilder.tsx
@@ -1,5 +1,5 @@
 import { Component } from "react";
-import { Course, Section, SOC_API, SOC_Generic, SectionJSON } from "@scripts/soc";
+import { Course, Section, SOC_API, SOC_Generic } from "@scripts/soc";
 import {
     Schedule,
     ScheduleGenerator,
@@ -72,7 +72,7 @@ export default class ScheduleBuilder extends Component<Props, States> {
                 prevState.selections.filter(notEmpty),
             )
         ) {
-            console.log(`Modifying selections:${this.state.soc?.getSOCProgramString()},${this.state.soc?.getSOCTermString()}`)
+            console.log(`Updating local storage data for "selections:${this.state.soc?.getSOCProgramString()},${this.state.soc?.getSOCTermString()}"`)
             localStorage.setItem(`selections:${this.state.soc?.getSOCProgramString()},${this.state.soc?.getSOCTermString()}`, JSON.stringify(this.state.selections));
             if (this.state.generator) {
                 // Make sure generator is not null
@@ -116,19 +116,16 @@ export default class ScheduleBuilder extends Component<Props, States> {
     }
 
     async loadStoredSelections(termStr: string, programStr: string) {
-        console.log(`looking for selections:${programStr},${termStr}`)
+        console.log(`Searching for local storage data for "selections:${programStr},${termStr}"`)
         const data = localStorage.getItem(`selections:${programStr},${termStr}`);
         if (data != null) {
-            console.log("Stored selection data found")
-            console.log(JSON.parse(data));
-            let selectionArray = JSON.parse(data).map((selectionJson: SectionJSON[]): Selection => {
+            console.log("Stored selection data found", JSON.parse(data));
+            let selectionArray = JSON.parse(data).map((selectionJson: Section[]): Selection => {
                 return Selection.parseJSON(selectionJson);;
             });
             this.setState({ selections: selectionArray });
-            console.log("parsed the selection array");
-            console.log(selectionArray);
         } else {
-            console.log("Stored selection data not present")
+            console.log("Stored selection data not present.")
         }
     }
 

--- a/app/src/components/ScheduleBuilder.tsx
+++ b/app/src/components/ScheduleBuilder.tsx
@@ -60,7 +60,6 @@ export default class ScheduleBuilder extends Component<Props, States> {
         });
     }
 
-    // TODO(ccastillo): Make it so search reruns automatically when term is updated
     componentDidUpdate(
         _prevProps: Readonly<Props>,
         prevState: Readonly<States>,
@@ -157,6 +156,9 @@ export default class ScheduleBuilder extends Component<Props, States> {
                         ),
                 );
                 this.newSelection(ind, sectionsToAdd); // Add the section that have not been added
+            }
+            else {
+                alert("Error dragging course or section to selections from search results. Please try re-running your search.")
             }
         }
     }

--- a/app/src/scripts/scheduleGenerator.tsx
+++ b/app/src/scripts/scheduleGenerator.tsx
@@ -1,7 +1,17 @@
-import { Section, SOC_Generic } from "@scripts/soc";
+import { Section, SOC_Generic, SectionJSON } from "@scripts/soc";
 import { Term } from "@constants/soc";
 
-export class Selection extends Array<Section> {}
+
+
+
+
+export class Selection extends Array<Section> {
+    static parseJSON(selectionJson: SectionJSON[]): Selection {
+        return selectionJson.map((sectionJson: SectionJSON) => {
+            return Section.parseJSON(sectionJson);
+        });
+    }
+}
 
 export class Schedule extends Array<Section> {
     term: Term;

--- a/app/src/scripts/scheduleGenerator.tsx
+++ b/app/src/scripts/scheduleGenerator.tsx
@@ -1,4 +1,4 @@
-import { Section, SOC_Generic, SectionJSON } from "@scripts/soc";
+import { Section, SOC_Generic } from "@scripts/soc";
 import { Term } from "@constants/soc";
 
 
@@ -6,8 +6,8 @@ import { Term } from "@constants/soc";
 
 
 export class Selection extends Array<Section> {
-    static parseJSON(selectionJson: SectionJSON[]): Selection {
-        return selectionJson.map((sectionJson: SectionJSON) => {
+    static parseJSON(selectionJson: Section[]): Selection {
+        return selectionJson.map((sectionJson: Section) => {
             return Section.parseJSON(sectionJson);
         });
     }

--- a/app/src/scripts/soc/meet.ts
+++ b/app/src/scripts/soc/meet.ts
@@ -72,6 +72,66 @@ export class MeetTime {
             this.periodEnd >= other.periodBegin
         );
     }
+
+    static parseMeetings = (meetingsJson: MeetingsJSON): Meetings => {
+        let meetings = noMeetings();
+        meetingsJson.M.forEach((meetTimeJson: MeetTimeJSON) => meetings.M.push(MeetTime.parseMeetTime(meetTimeJson)));
+        meetingsJson.T.forEach((meetTimeJson: MeetTimeJSON) => meetings.T.push(MeetTime.parseMeetTime(meetTimeJson)));
+        meetingsJson.W.forEach((meetTimeJson: MeetTimeJSON) => meetings.W.push(MeetTime.parseMeetTime(meetTimeJson)));
+        meetingsJson.R.forEach((meetTimeJson: MeetTimeJSON) => meetings.R.push(MeetTime.parseMeetTime(meetTimeJson)));
+        meetingsJson.F.forEach((meetTimeJson: MeetTimeJSON) => meetings.F.push(MeetTime.parseMeetTime(meetTimeJson)));
+        meetingsJson.S.forEach((meetTimeJson: MeetTimeJSON) => meetings.S.push(MeetTime.parseMeetTime(meetTimeJson)));
+        return meetings;
+    }
+
+    static parseMeetTime = (meetTimeJson: MeetTimeJSON): MeetTime => {
+        let meetTime = new MeetTime(Term.Spring, this.emptyMeetTime(), false);
+        meetTime.term = this.parseTermEnum(meetTimeJson.term);
+        meetTime.periodBegin = meetTimeJson.periodBegin;
+        meetTime.periodEnd = meetTimeJson.periodEnd;
+        meetTime.timeBegin = meetTimeJson.timeBegin;
+        meetTime.timeEnd = meetTimeJson.timeEnd;
+        meetTime.bldg = meetTimeJson.bldg;
+        meetTime.room = meetTimeJson.room;
+        meetTime.isOnline = meetTimeJson.isOnline;
+        meetTime.locationID = meetTimeJson.locationID;
+        return meetTime;
+    }
+
+    static emptyMeetTime = () => {
+        return {
+            meetNo: 0,
+            meetDays: [],
+            meetTimeBegin: "",
+            meetTimeEnd: "",
+            meetPeriodBegin: "",
+            meetPeriodEnd: "",
+            meetBuilding: "",
+            meetBldgCode: "",
+            meetRoom: "",
+        }
+    }
+
+    static parseTermEnum = (term: string): Term => {
+        if (term == "Spring") {
+            return Term.Spring;
+        } else if (term == "Summer") {
+            return Term.Summer;
+        } else if (term == "Summer A") {
+            return Term.Summer_A;
+        } else if (term == "Summer B") {
+            return Term.Summer_B;
+        } else if (term == "Summer C") {
+            return Term.Summer_C;
+        } else if (term == "Fall") {
+            return Term.Fall;
+        }
+        else {
+            console.log(`Failed to find Term enum for ${term}, defaulting to 'Spring'`)
+            return Term.Spring;
+        }
+    }
+
 }
 
 export type Meetings = Record<API_Day, MeetTime[]>;
@@ -85,4 +145,27 @@ export function noMeetings(): Meetings {
         [API_Day.Fri]: [],
         [API_Day.Sat]: [],
     };
+}
+
+// TODO(ccastillo): Remove serialization interfaces if unused, i.e. figure out if even need these interfaces
+// Interfaces used for serialization
+export interface MeetTimeJSON {
+    term: string;
+    periodBegin: number;
+    periodEnd: number;
+    timeBegin: string;
+    timeEnd: string;
+    bldg: string;
+    room: string;
+    isOnline: boolean;
+    locationID: string | null;
+}
+
+export interface MeetingsJSON {
+    M: MeetTimeJSON[];
+    T: MeetTimeJSON[];
+    W: MeetTimeJSON[];
+    R: MeetTimeJSON[];
+    F: MeetTimeJSON[];
+    S: MeetTimeJSON[];
 }

--- a/app/src/scripts/soc/meet.ts
+++ b/app/src/scripts/soc/meet.ts
@@ -73,29 +73,20 @@ export class MeetTime {
         );
     }
 
-    static parseMeetings = (meetingsJson: MeetingsJSON): Meetings => {
+    static parseMeetings = (meetingsJson: Meetings): Meetings => {
         let meetings = noMeetings();
-        meetingsJson.M.forEach((meetTimeJson: MeetTimeJSON) => meetings.M.push(MeetTime.parseMeetTime(meetTimeJson)));
-        meetingsJson.T.forEach((meetTimeJson: MeetTimeJSON) => meetings.T.push(MeetTime.parseMeetTime(meetTimeJson)));
-        meetingsJson.W.forEach((meetTimeJson: MeetTimeJSON) => meetings.W.push(MeetTime.parseMeetTime(meetTimeJson)));
-        meetingsJson.R.forEach((meetTimeJson: MeetTimeJSON) => meetings.R.push(MeetTime.parseMeetTime(meetTimeJson)));
-        meetingsJson.F.forEach((meetTimeJson: MeetTimeJSON) => meetings.F.push(MeetTime.parseMeetTime(meetTimeJson)));
-        meetingsJson.S.forEach((meetTimeJson: MeetTimeJSON) => meetings.S.push(MeetTime.parseMeetTime(meetTimeJson)));
+        meetingsJson.M.forEach((meetTimeJson: MeetTime) => meetings.M.push(MeetTime.parseMeetTime(meetTimeJson)));
+        meetingsJson.T.forEach((meetTimeJson: MeetTime) => meetings.T.push(MeetTime.parseMeetTime(meetTimeJson)));
+        meetingsJson.W.forEach((meetTimeJson: MeetTime) => meetings.W.push(MeetTime.parseMeetTime(meetTimeJson)));
+        meetingsJson.R.forEach((meetTimeJson: MeetTime) => meetings.R.push(MeetTime.parseMeetTime(meetTimeJson)));
+        meetingsJson.F.forEach((meetTimeJson: MeetTime) => meetings.F.push(MeetTime.parseMeetTime(meetTimeJson)));
+        meetingsJson.S.forEach((meetTimeJson: MeetTime) => meetings.S.push(MeetTime.parseMeetTime(meetTimeJson)));
         return meetings;
     }
 
-    static parseMeetTime = (meetTimeJson: MeetTimeJSON): MeetTime => {
+    static parseMeetTime = (meetTimeJson: MeetTime): MeetTime => {
         let meetTime = new MeetTime(Term.Spring, this.emptyMeetTime(), false);
-        meetTime.term = this.parseTermEnum(meetTimeJson.term);
-        meetTime.periodBegin = meetTimeJson.periodBegin;
-        meetTime.periodEnd = meetTimeJson.periodEnd;
-        meetTime.timeBegin = meetTimeJson.timeBegin;
-        meetTime.timeEnd = meetTimeJson.timeEnd;
-        meetTime.bldg = meetTimeJson.bldg;
-        meetTime.room = meetTimeJson.room;
-        meetTime.isOnline = meetTimeJson.isOnline;
-        meetTime.locationID = meetTimeJson.locationID;
-        return meetTime;
+        return Object.assign(meetTime, meetTimeJson);
     }
 
     static emptyMeetTime = () => {
@@ -111,27 +102,6 @@ export class MeetTime {
             meetRoom: "",
         }
     }
-
-    static parseTermEnum = (term: string): Term => {
-        if (term == "Spring") {
-            return Term.Spring;
-        } else if (term == "Summer") {
-            return Term.Summer;
-        } else if (term == "Summer A") {
-            return Term.Summer_A;
-        } else if (term == "Summer B") {
-            return Term.Summer_B;
-        } else if (term == "Summer C") {
-            return Term.Summer_C;
-        } else if (term == "Fall") {
-            return Term.Fall;
-        }
-        else {
-            console.log(`Failed to find Term enum for ${term}, defaulting to 'Spring'`)
-            return Term.Spring;
-        }
-    }
-
 }
 
 export type Meetings = Record<API_Day, MeetTime[]>;
@@ -145,27 +115,4 @@ export function noMeetings(): Meetings {
         [API_Day.Fri]: [],
         [API_Day.Sat]: [],
     };
-}
-
-// TODO(ccastillo): Remove serialization interfaces if unused, i.e. figure out if even need these interfaces
-// Interfaces used for serialization
-export interface MeetTimeJSON {
-    term: string;
-    periodBegin: number;
-    periodEnd: number;
-    timeBegin: string;
-    timeEnd: string;
-    bldg: string;
-    room: string;
-    isOnline: boolean;
-    locationID: string | null;
-}
-
-export interface MeetingsJSON {
-    M: MeetTimeJSON[];
-    T: MeetTimeJSON[];
-    W: MeetTimeJSON[];
-    R: MeetTimeJSON[];
-    F: MeetTimeJSON[];
-    S: MeetTimeJSON[];
 }

--- a/app/src/scripts/soc/section.ts
+++ b/app/src/scripts/soc/section.ts
@@ -4,7 +4,7 @@ import {
     API_Section,
     API_Section_Type,
 } from "@scripts/apiTypes";
-import { Meetings, MeetTime, noMeetings, MeetingsJSON } from "@scripts/soc";
+import { Meetings, MeetTime, noMeetings } from "@scripts/soc";
 import { Term } from "@constants/soc";
 import { MinMax } from "@scripts/utils.ts";
 
@@ -74,16 +74,9 @@ export class Section {
         );
     }
 
-    static parseJSON = (sectionJson: SectionJSON): Section => {
+    static parseJSON = (sectionJson: Section): Section => {
         let section = new Section("0#0", Term.Fall, this.emptyApiSection(), "MAS3114");
-        section.uid = sectionJson.uid;
-        section.term = sectionJson.term;
-        section.type = this.parseApiSectionType(sectionJson.type);
-        section.number = sectionJson.number;
-        section.courseCode = sectionJson.courseCode;
-        section.displayName = sectionJson.displayName;
-        section.deptControlled = sectionJson.deptControlled;
-        section.instructors = sectionJson.instructors;
+        section = Object.assign(section, sectionJson);
         section.credits = new MinMax<number>(
             sectionJson.credits.min,
             sectionJson.credits.max,
@@ -131,38 +124,4 @@ export class Section {
             }
         }
     }
-
-    static parseApiSectionType = (type: string): API_Section_Type => {
-        if (type == "PC") {
-            return API_Section_Type.PrimarilyClassroom;
-        } else if (type == "HB") {
-            return API_Section_Type.Hybrid;
-        } else if (type == "PD") {
-            return API_Section_Type.MostlyOnline;
-        } else if (type == "AD") {
-            return API_Section_Type.Online;
-        }
-        else {
-            console.log(`Failed to find API_Section_Type enum for ${type}, defaulting to 'PC'`)
-            return API_Section_Type.PrimarilyClassroom;
-        }
-    }
-}
-
-// TODO(ccastillo): Remove serialization interfaces if unused, i.e. figure out if even need these interfaces
-// Interfaces used for serialization
-export interface SectionJSON {
-    uid: string;
-    term: Term;
-    type: string;
-    number: number;
-    courseCode: string;
-    displayName: string;
-    deptControlled: boolean;
-    instructors: string[];
-    credits: {
-        min: number;
-        max: number;
-    }
-    meetings: MeetingsJSON;
 }

--- a/app/src/scripts/soc/section.ts
+++ b/app/src/scripts/soc/section.ts
@@ -4,7 +4,7 @@ import {
     API_Section,
     API_Section_Type,
 } from "@scripts/apiTypes";
-import { Meetings, MeetTime, noMeetings } from "@scripts/soc";
+import { Meetings, MeetTime, noMeetings, MeetingsJSON } from "@scripts/soc";
 import { Term } from "@constants/soc";
 import { MinMax } from "@scripts/utils.ts";
 
@@ -73,4 +73,96 @@ export class Section {
             this.type == API_Section_Type.MostlyOnline
         );
     }
+
+    static parseJSON = (sectionJson: SectionJSON): Section => {
+        let section = new Section("0#0", Term.Fall, this.emptyApiSection(), "MAS3114");
+        section.uid = sectionJson.uid;
+        section.term = sectionJson.term;
+        section.type = this.parseApiSectionType(sectionJson.type);
+        section.number = sectionJson.number;
+        section.courseCode = sectionJson.courseCode;
+        section.displayName = sectionJson.displayName;
+        section.deptControlled = sectionJson.deptControlled;
+        section.instructors = sectionJson.instructors;
+        section.credits = new MinMax<number>(
+            sectionJson.credits.min,
+            sectionJson.credits.max,
+        );
+        section.meetings = MeetTime.parseMeetings(sectionJson.meetings);
+        return section;
+    }
+
+    static emptyApiSection = (): API_Section => {
+        return {
+            number: "",
+            classNumber: 0,
+            gradBasis: 0,
+            acadCareer: 0,
+            display: "",
+            credits: 0,
+            credits_min: 0,
+            credits_max: 0,
+            note: "",
+            dNote: "",
+            genEd: [],
+            quest: [],
+            sectWeb: API_Section_Type.PrimarilyClassroom,
+            rotateTitle: "",
+            deptCode: 0,
+            deptName: "",
+            openSeats: 0,
+            courseFee: 0,
+            lateFlag: "",
+            EEP: "",
+            LMS: "",
+            instructors: [],
+            meetTimes: [],
+            addEligible: "",
+            grWriting: "",
+            finalExam: "",
+            dropaddDeadline: "",
+            pastDeadline: false,
+            startDate: "",
+            endDate: "",
+            waitList: {
+                isEligible: "",
+                cap: 0,
+                total: 0,
+            }
+        }
+    }
+
+    static parseApiSectionType = (type: string): API_Section_Type => {
+        if (type == "PC") {
+            return API_Section_Type.PrimarilyClassroom;
+        } else if (type == "HB") {
+            return API_Section_Type.Hybrid;
+        } else if (type == "PD") {
+            return API_Section_Type.MostlyOnline;
+        } else if (type == "AD") {
+            return API_Section_Type.Online;
+        }
+        else {
+            console.log(`Failed to find API_Section_Type enum for ${type}, defaulting to 'PC'`)
+            return API_Section_Type.PrimarilyClassroom;
+        }
+    }
+}
+
+// TODO(ccastillo): Remove serialization interfaces if unused, i.e. figure out if even need these interfaces
+// Interfaces used for serialization
+export interface SectionJSON {
+    uid: string;
+    term: Term;
+    type: string;
+    number: number;
+    courseCode: string;
+    displayName: string;
+    deptControlled: boolean;
+    instructors: string[];
+    credits: {
+        min: number;
+        max: number;
+    }
+    meetings: MeetingsJSON;
 }

--- a/app/src/scripts/soc/soc.tsx
+++ b/app/src/scripts/soc/soc.tsx
@@ -40,6 +40,16 @@ export abstract class SOC_Generic {
         throw new Error("SOC initializer not implemented.");
     }
 
+    /* TERM AND PROGRAM */
+
+    getSOCTermString = (): string => {
+        return this.info.termStr;
+    }
+
+    getSOCProgramString = (): string => {
+        return getProgramString(this.info.program);
+    }
+
     /* UID */
 
     /**


### PR DESCRIPTION
Issue https://github.com/ufosc/SwampScheduler/issues/40 suggests that schedules should autosave. Because saving all the possible schedules for a given set of selections may take up a large amount of space, I instead implemented a way for the selections to autosave. Also, this allows the user to not have to recreate all previous selections upon reloading the page. However, this implementation might require more time for schedules to re-generate.